### PR TITLE
Fix error prone typos

### DIFF
--- a/src/libs/qmljs/qmljsimportdependencies.cpp
+++ b/src/libs/qmljs/qmljsimportdependencies.cpp
@@ -72,7 +72,7 @@ int ImportMatchStrength::compareMatch(const ImportMatchStrength &o) const
         int v2 = o.m_match.at(i);
         if (v1 < v2)
             return -1;
-        if (v2 > v1)
+        if (v1 > v2)
             return 1;
     }
     if (len1 < len2)

--- a/src/libs/qtcreatorcdbext/symbolgroupvalue.cpp
+++ b/src/libs/qtcreatorcdbext/symbolgroupvalue.cpp
@@ -1574,6 +1574,7 @@ static KnownType knownClassTypeHelper(const std::string &type,
     case 29:
         if (!type.compare(qPos, 29, "QXmlStreamNotationDeclaration"))
             return KT_QXmlStreamNotationDeclaration;
+        break;
     case 30:
         if (!type.compare(qPos, 30, "QPatternist::SequenceType::Ptr"))
             return KT_QPatternist_SequenceType_Ptr;

--- a/src/plugins/android/androidrunner.cpp
+++ b/src/plugins/android/androidrunner.cpp
@@ -811,7 +811,7 @@ void AndroidRunner::setRunnable(const AndroidRunnable &runnable)
 
 void AndroidRunner::launchAVD()
 {
-    if (!m_target && !m_target->project())
+    if (!m_target || !m_target->project())
         return;
 
     int deviceAPILevel = AndroidManager::minimumSDK(m_target);

--- a/src/plugins/debugger/watchdata.cpp
+++ b/src/plugins/debugger/watchdata.cpp
@@ -265,6 +265,7 @@ public:
                     case 8:
                         return decodeArrayHelper<qint64>(encoding.size);
                 }
+                break;
             case DebuggerEncoding::HexEncodedUnsignedInteger:
                 switch (encoding.size) {
                     case 1:

--- a/src/plugins/pythoneditor/pythonscanner.cpp
+++ b/src/plugins/pythoneditor/pythonscanner.cpp
@@ -202,7 +202,7 @@ FormatToken Scanner::readIdentifier()
 
     // List of python built-in functions and objects
     static const QSet<QString> builtins = {
-        "range", "xrange", "int", "float", "long", "hex", "oct" "chr", "ord",
+        "range", "xrange", "int", "float", "long", "hex", "oct", "chr", "ord",
         "len", "abs", "None", "True", "False"
     };
 


### PR DESCRIPTION
Hello!
I'm a member of the Pinguem.ru competition on finding errors in open source projects.
I found a couple issues/misprints in Qt Creator project's code. Althought they are just simple typos, they can cause Qt Creator's misbehaviour in some scenarios.

#### efc74b0: python scanner: "oct" and "chr" highlight fix
- Create a `bug.py` file with `octchr = chr(42) + oct(42)` contents;
- Open the file with Qt Creator;
- You'll see that `oct` and `chr` builtin functions are not highlighted, but variable `octchr` IS highligted. Reason: missed comma.

#### af9237c: avoid crash while Android Virtual Device Manager launch
There can be a crash of the program in case if Android Virtual Device Manager is launched with missing target. Reason: `&&` instead of `||` typo;

#### 75a175d: QmlJsImport: correct ImportMatchStrength comparison
Loading of JS import dependencies could went wrong because of incorrect `ImportMatchStrength`s comparison. There was a big chance that dependency strength could be treated _smaller_ in case when it actually is _bigger_. Reason: `v2 > v1` instead of `v1 > v2` typo.

#### eace61a: fix some missing breaks in switches
Just some missing `break`s fix. They could not cause anything wrong but stil it is better them to be fixed than unfixed.

<br>

All these typos were found by PVS-Studio static analyzer:
- [V653](https://www.viva64.com/en/w/v653/) A suspicious string consisting of two parts is used for initialization. It is possible that a comma is missing. Consider inspecting this literal: "oct" "chr". pythonscanner.cpp 205
- [V522](https://www.viva64.com/en/w/v522/) There might be dereferencing of a potential null pointer 'm_target'. androidrunner.cpp 814
- [V649](https://www.viva64.com/en/w/v649/) There are two 'if' statements with identical conditional expressions. The first 'if' statement contains function return. This means that the second 'if' statement is senseless. Check lines: 73, 75. qmljsimportdependencies.cpp 75
- [V796](https://www.viva64.com/en/w/v796/) It is possible that 'break' statement is missing in switch statement. watchdata.cpp 267
- [V796](https://www.viva64.com/en/w/v796/) It is possible that 'break' statement is missing in switch statement. symbolgroupvalue.cpp 1576

<br>

@ossilator :
- I'm aware of https://wiki.qt.io/Qt_Contribution_Guidelines;
- This all is supposed to be about drawing attention of any of Qt developers to a small though error prone typos. I'm not ready to go through all your contribution guideline process just to fix thoose misprints. But what I can do is this PR. Maybe someone of you will just look into this and fix it quickly since it's rather simple and cannot lead to any bugs or regressions.

BR,
Nikolay