### PR TITLE
Allow C++17 for Msvc2017

### DIFF
--- a/src/plugins/projectexplorer/abstractmsvctoolchain.cpp
+++ b/src/plugins/projectexplorer/abstractmsvctoolchain.cpp
@@ -138,8 +138,15 @@ ToolChain::CompilerFlags AbstractMsvcToolChain::compilerFlags(const QStringList 
     case Abi::WindowsMsvc2012Flavor: flags |= StandardCxx11;
         break;
     case Abi::WindowsMsvc2013Flavor:
-    case Abi::WindowsMsvc2015Flavor:
-    case Abi::WindowsMsvc2017Flavor: flags |= StandardCxx14;
+    case Abi::WindowsMsvc2015Flavor: flags |= StandardCxx14;
+        break;
+    case Abi::WindowsMsvc2017Flavor:
+        if (cxxflags.contains(QLatin1String("/std:c++17")))
+          flags |= StandardCxx17;
+        else if (cxxflags.contains(QLatin1String("/std:c++latest")))
+          flags |= StandardCxx17;
+        else
+          flags |= StandardCxx14;
         break;
     default:
         break;


### PR DESCRIPTION
Msvc2017 introduced a `/std:` option, to select the C++ language version. This should be reflected in QtCreator or the Clang Code Model uses an outdated language version.