### PR TITLE
Fix CMake variables pass to qtcreator config.

### DIFF
--- a/src/plugins/cmakeprojectmanager/cmakekitinformation.cpp
+++ b/src/plugins/cmakeprojectmanager/cmakekitinformation.cpp
@@ -535,6 +535,13 @@ CMakeConfig CMakeConfigurationKitInformation::defaultConfiguration(const Kit *k)
     config << CMakeConfigItem(CMAKE_C_TOOLCHAIN_KEY, "%{Compiler:Executable:C}");
     config << CMakeConfigItem(CMAKE_CXX_TOOLCHAIN_KEY, "%{Compiler:Executable:Cxx}");
 
+    // get cmake variables
+    QMap<QString, QString> CMakeVariables = CMakeKitInformation::cmakeTool(k)->getCMakeVariables();
+    for (auto it = CMakeVariables.cbegin(); it != CMakeVariables.cend(); ++it)
+    {
+        config << CMakeConfigItem::fromString(it.key() + "=" + it.value());
+    }
+
     return config;
 }
 

--- a/src/plugins/cmakeprojectmanager/cmaketool.cpp
+++ b/src/plugins/cmakeprojectmanager/cmaketool.cpp
@@ -71,6 +71,16 @@ CMakeTool::CMakeTool(const QVariantMap &map, bool fromSdk) : m_isAutoDetected(fr
     m_isAutoRun = map.value(CMAKE_INFORMATION_AUTORUN, true).toBool();
     m_autoCreateBuildDirectory = map.value(CMAKE_INFORMATION_AUTO_CREATE_BUILD_DIRECTORY, false).toBool();
 
+    // get cmake variables
+    const char cmakeVarIdentifier[] = "CMAKE_";
+
+    for (auto it = map.cbegin(); it != map.cend(); ++it)
+    {
+        if (it.key().startsWith(cmakeVarIdentifier)) {
+            m_CMakeVariables.insert(it.key(), it.value().toString());
+        }
+    }
+
     //loading a CMakeTool from SDK is always autodetection
     if (!fromSdk)
         m_isAutoDetected = map.value(CMAKE_INFORMATION_AUTODETECTED, false).toBool();
@@ -81,6 +91,11 @@ CMakeTool::CMakeTool(const QVariantMap &map, bool fromSdk) : m_isAutoDetected(fr
 Core::Id CMakeTool::createId()
 {
     return Core::Id::fromString(QUuid::createUuid().toString());
+}
+
+QMap<QString, QString> CMakeTool::getCMakeVariables() const
+{
+    return m_CMakeVariables;
 }
 
 void CMakeTool::setCMakeExecutable(const Utils::FileName &executable)
@@ -155,6 +170,13 @@ QVariantMap CMakeTool::toMap() const
     data.insert(CMAKE_INFORMATION_AUTORUN, m_isAutoRun);
     data.insert(CMAKE_INFORMATION_AUTO_CREATE_BUILD_DIRECTORY, m_autoCreateBuildDirectory);
     data.insert(CMAKE_INFORMATION_AUTODETECTED, m_isAutoDetected);
+
+    // add cmake variables
+    for (auto it = m_CMakeVariables.cbegin(); it != m_CMakeVariables.cend(); ++it)
+    {
+        data.insert(it.key(), it.value());
+    }
+
     return data;
 }
 

--- a/src/plugins/cmakeprojectmanager/cmaketool.h
+++ b/src/plugins/cmakeprojectmanager/cmaketool.h
@@ -87,6 +87,7 @@ public:
 
     Core::Id id() const { return m_id; }
     QVariantMap toMap () const;
+    QMap<QString, QString> getCMakeVariables() const;
 
     void setCMakeExecutable(const Utils::FileName &executable);
     void setAutorun(bool autoRun);
@@ -130,6 +131,8 @@ private:
     bool m_isAutoRun = true;
     bool m_isAutoDetected = false;
     bool m_autoCreateBuildDirectory = false;
+
+    QMap<QString, QString> m_CMakeVariables;
 
     mutable bool m_didAttemptToRun = false;
     mutable bool m_didRun = false;


### PR DESCRIPTION
Since sdktool supports passing CMake variables
to config in the form of <KEY> <TYPE:VALUE>,
we should be able to use them in the generated kit.