### PR TITLE
auto include header text under mouse cursor

### DIFF
--- a/src/plugins/cpptools/cpptoolsplugin.cpp
+++ b/src/plugins/cpptools/cpptoolsplugin.cpp
@@ -180,6 +180,13 @@ bool CppToolsPlugin::initialize(const QStringList &arguments, QString *error)
     // Actions
     Context context(CppEditor::Constants::CPPEDITOR_ID);
 
+     QAction *autoIncludeAction = new QAction(tr("Include text under cursor"), this);
+    Command *includeCommand = ActionManager::registerAction(autoIncludeAction, Constants::AUTO_INCLUD_UNDER_CURSOR, context, true);
+    //includeCommand->setDefaultKeySequence(QKeySequence(Qt::Key_F4));
+    mcpptools->addAction(includeCommand);
+    connect(autoIncludeAction, &QAction::triggered,
+            this, &CppToolsPlugin::autoIncludeAction);
+    
     QAction *switchAction = new QAction(tr("Switch Header/Source"), this);
     Command *command = ActionManager::registerAction(switchAction, Constants::SWITCH_HEADER_SOURCE, context, true);
     command->setDefaultKeySequence(QKeySequence(Qt::Key_F4));

--- a/src/plugins/cpptools/cpptoolsreuse.cpp
+++ b/src/plugins/cpptools/cpptoolsreuse.cpp
@@ -195,6 +195,12 @@ bool isQtKeyword(const QStringRef &text)
     return false;
 }
 
+void autoIncludeHeader()
+{
+  auto header = identifierUnderCursor();
+  
+}
+  
 void switchHeaderSource()
 {
     const Core::IDocument *currentDocument = Core::EditorManager::currentDocument();

--- a/src/plugins/cpptools/cpptoolsreuse.cpp
+++ b/src/plugins/cpptools/cpptoolsreuse.cpp
@@ -198,7 +198,9 @@ bool isQtKeyword(const QStringRef &text)
 void autoIncludeHeader()
 {
   auto header = identifierUnderCursor();
-  
+  // include header in first line of document
+  const Core::IDocument *currentDocument = Core::EditorManager::currentDocument();
+  //...
 }
   
 void switchHeaderSource()

--- a/src/plugins/cpptools/cpptoolsreuse.h
+++ b/src/plugins/cpptools/cpptoolsreuse.h
@@ -70,7 +70,10 @@ enum class CacheUsage { ReadWrite, ReadOnly };
 
 QString CPPTOOLS_EXPORT correspondingHeaderOrSource(const QString &fileName, bool *wasHeader = 0,
                                                     CacheUsage cacheUsage = CacheUsage::ReadWrite);
+void CPPTOOLS_EXPORT autoIncludeHeader();
+  
 void CPPTOOLS_EXPORT switchHeaderSource();
+
 
 class CppCodeModelSettings;
 QSharedPointer<CppCodeModelSettings> CPPTOOLS_EXPORT codeModelSettings();


### PR DESCRIPTION
when we right click on a text (e.g QPushButton) it automatically includes it's header (#include <QPushButton>). sorry I cannot complete it's code, if you can please complete the code.
thanks.