### PR TITLE
Fix: LLDB gets the wrong bitfield value.

### DIFF
--- a/share/qtcreator/debugger/dumper.py
+++ b/share/qtcreator/debugger/dumper.py
@@ -169,6 +169,10 @@ def xwarn(message):
 def error(message):
     raise RuntimeError(message)
 
+def my_debuger(msg):
+    if False:
+        warn('\033[0;101m\n[DEBUG]:%s\033[0m\n' % msg)
+
 def showException(msg, exType, exValue, exTraceback):
     DumperBase.showException(msg, exType, exValue, exTraceback)
 
@@ -3076,6 +3080,7 @@ class DumperBase:
                 error('BAD INDEX TYPE %s' % type(index))
             field.check()
 
+            #('EXTRACT FIELD: %s, BASE 0x%x' % (field, self.address()))
             #warn('EXTRACT FIELD: %s, BASE 0x%x' % (field, self.address()))
             if self.type.code == TypeCodePointer:
                 #warn('IS TYPEDEFED POINTER!')
@@ -3099,6 +3104,7 @@ class DumperBase:
             if self.type.code == TypeCodeReference:
                 return self.dereference().extractField(field)
             #warn('FIELD: %s ' % field)
+
             val = self.dumper.Value(self.dumper)
             val.name = field.name
             val.isBaseClass = field.isBase
@@ -3118,18 +3124,12 @@ class DumperBase:
             fieldType = field.fieldType()
 
             if fieldType.code == TypeCodeBitfield:
-                fieldBitpos -= fieldOffset * 8
-                ldata = self.data()
-                data = 0
-                for i in range(fieldSize):
-                    data = data << 8
-                    if self.dumper.isBigEndian:
-                        byte = ldata[i]
-                    else:
-                        byte = ldata[fieldOffset + fieldSize - 1 - i]
-                    data += ord(byte)
-                data = data >> fieldBitpos
-                data = data & ((1 << fieldBitsize) - 1)
+                hex_str = self.data().encode('hex')
+                bin_str = format(int(hex_str, 16), 'x<b')
+
+                start = field.bitpos
+                end = field.bitpos+field.bitsize
+                data = int(bin_str[start:end], 2)
                 val.lvalue = data
                 val.laddress = None
                 return val
@@ -3169,7 +3169,6 @@ class DumperBase:
                     fields = tdata.lfields
                 else:
                     fields = list(tdata.lfields(self))
-
             #warn("FIELDS: %s" % fields)
             res = []
             for field in fields:


### PR DESCRIPTION
> When I use qtcreator to debug some projects, I didn't get the correct value
> from the lldb debuger. Like this code snippet:

```c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

#define LRU_BITS 24

#define OBJ_SHARED_REFCOUNT INT_MAX
typedef struct redisObject {
    unsigned type:4;
    unsigned encoding:4;
    unsigned lru:LRU_BITS; /* LRU time (relative to global lru_clock) or
                            * LFU data (least significant 8 bits frequency
                            * and most significant 16 bits access time). */
    int refcount;
    void *ptr;
} robj;


int main()
{
    robj x;

    unsigned char data[] = {
          0x80, 0x8f, 0xf6, 0x8b, 0x01, 0x00, 0x00, 0x00,
          0x83, 0x26, 0x73, 0x55, 0x55, 0x55, 0x00, 0x00,
    };
    memcpy(&x, data, sizeof(struct redisObject));

    return 0;
}
```

I use `memcpy` to assign values to it, as a structure in `C`:
I should get the following value:
```
{
    type = 0,
    encoding = 8,
    lru = 9172623,  // 0x8bf68f
    refcount = 1,
    ptr = 0x555555732683
}
```

But I got this(The debug python file I add it in last):
```
{
    type = 0,
    encoding = 8,
    lru = 16158592, // 0xf68f80
    refcount = 1,
    ptr = 0x555555732683
}
```

The LRU value isn't correct;

Here is the memory dump:

```
0x7fffffffd480:	0x80	0x8f	0xf6	0x8b	0x01	0x00	0x00	0x00
0x7fffffffd488:	0x83	0x26	0x73	0x55
```

You see, what happend, the offset of `lru` is not correct, the first 0x80 should not
appear in the data, the offset should start from the bitpos 8, not 0.

So, I did some checks on the debugger, the error is here: In lldbbridge.py:listMembers, I see this:

```
bitpos = bitpos % 8 # Reported type is always wrapping type!
```

For bitfield value, you just `mod 8` to get the relative bitpos.
When I watch `lru` value, whose bitpos is 8,
now it is 0. There is no doubt I will get the wrong value.

Maybe as a bitfield value, it is more appropriate to keep bitpos as an absolute offset,
so I took it upon myself to keep bitpos as an absolute offset.
You know, debugging such a large python file is not a simple task. so I added
some debugging tips to those files, hoping to help others print some debugging information.

The debug python script I used was placed in the attachment, and I didn't find any such bugs in gdb.

Thanks to the qtcreator team. I hope it will get better and better.

Best wishes.


[debugger.tar.gz](https://github.com/qt-creator/qt-creator/files/2408757/debugger.tar.gz)
