### PR TITLE
Fixed bug with not correctly open *.ui.qml file

### DIFF
--- a/src/plugins/coreplugin/editormanager/editormanager.cpp
+++ b/src/plugins/coreplugin/editormanager/editormanager.cpp
@@ -732,7 +732,10 @@ IEditor *EditorManagerPrivate::openEditorWith(const QString &fileName, Core::Id 
 
     IEditor *openedEditor = 0;
     if (views.isEmpty()) {
-        openedEditor = EditorManager::openEditor(fileName, editorId);
+        //This function triggered via contect menu "Open With"
+        //When we opened any qml files with QMLJS editor we don't auto switch to Design Mode because of DoNotSwitchToDesignMode
+        //If open another files flag DoNotSwitchToDesignMode does not affect anything
+        openedEditor = EditorManager::openEditor(fileName, editorId, EditorManager::DoNotSwitchToDesignMode);
     } else {
         if (EditorView *currentView = EditorManagerPrivate::currentEditorView()) {
             if (views.removeOne(currentView))


### PR DESCRIPTION
Now if open *.ui.qml file in QMLJS editor via context menu, the file is not auto switch to Design Mode