### PR TITLE
Fix html color code for Help plugin

### DIFF
--- a/share/qtcreator/translations/qtcreator_cs.ts
+++ b/share/qtcreator/translations/qtcreator_cs.ts
@@ -11172,8 +11172,12 @@ Přidat, upravit a odstranit dokumentové filtry, které v režimu nápovědy ur
         <translation>Žádný filtr</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head&gt;&lt;title&gt;No Documentation&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;b&gt;%1&lt;/b&gt;&lt;br/&gt;No documentation available.&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head&gt;&lt;title&gt;Dokumentace chybí&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;b&gt;%1&lt;/b&gt;&lt;br/&gt;Není dostupná žádná dokumentace.&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>No Documentation</source>
+        <translation>Dokumentace chybí</translation>
+    </message>
+    <message>
+        <source>No documentation available.</source>
+        <translation>Není dostupná žádná dokumentace.</translation>
     </message>
     <message>
         <source>Close current page</source>

--- a/share/qtcreator/translations/qtcreator_da.ts
+++ b/share/qtcreator/translations/qtcreator_da.ts
@@ -19956,8 +19956,12 @@ Tilføj, ændr, og fjern dokumentfiltre, som beslutter hvilke dokumentationssæt
         <translation>Ufiltreret</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head&gt;&lt;title&gt;No Documentation&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;font color=&quot;%1&quot;&gt;&lt;b&gt;%2&lt;/b&gt;&lt;/font&gt;&lt;br/&gt;&lt;font color=&quot;%3&quot;&gt;No documentation available.&lt;/font&gt;&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head&gt;&lt;title&gt;Ingen dokumentation&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;font color=&quot;%1&quot;&gt;&lt;b&gt;%2&lt;/b&gt;&lt;/font&gt;&lt;br/&gt;&lt;font color=&quot;%3&quot;&gt;Ingen tilgængelig dokumentation.&lt;/font&gt;&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>No Documentation</source>
+        <translation>Ingen dokumentation</translation>
+    </message>
+    <message>
+        <source>No documentation available.</source>
+        <translation>Ingen tilgængelig dokumentation.</translation>
     </message>
     <message>
         <source>System Information</source>

--- a/share/qtcreator/translations/qtcreator_de.ts
+++ b/share/qtcreator/translations/qtcreator_de.ts
@@ -5630,8 +5630,12 @@ Add, modify, and remove document filters, which determine the documentation set 
         <translation>Systeminformationen...</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head&gt;&lt;title&gt;No Documentation&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;font color=&quot;%1&quot;&gt;&lt;b&gt;%2&lt;/b&gt;&lt;/font&gt;&lt;br/&gt;&lt;font color=&quot;%3&quot;&gt;No documentation available.&lt;/font&gt;&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head&gt;&lt;title&gt;Dokumentation fehlt&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;font color=&quot;%1&quot;&gt;&lt;b&gt;%2&lt;/b&gt;&lt;/font&gt;&lt;br/&gt;&lt;font color=&quot;%3&quot;&gt;Es ist keine Dokumentation verfügbar.&lt;/font&gt;&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>No Documentation</source>
+        <translation>Dokumentation fehlt</translation>
+    </message>
+    <message>
+        <source>No documentation available.</source>
+        <translation>Es ist keine Dokumentation verfügbar.</translation>
     </message>
     <message>
         <source>System Information</source>

--- a/share/qtcreator/translations/qtcreator_fr.ts
+++ b/share/qtcreator/translations/qtcreator_fr.ts
@@ -12589,8 +12589,12 @@ Ajouter, modifier et supprimer des filtres de documents, lesquels déterminent l
         <translation>Sans filtre</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head&gt;&lt;title&gt;No Documentation&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;b&gt;%1&lt;/b&gt;&lt;br/&gt;No documentation available.&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head&gt;&lt;title&gt;Aucune documentation&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;b&gt;%1&lt;/b&gt;&lt;br/&gt;Aucune documentation disponible.&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>No Documentation</source>
+        <translation>Aucune documentation</translation>
+    </message>
+    <message>
+        <source>No documentation available.</source>
+        <translation>Aucune documentation disponible.</translation>
     </message>
     <message>
         <source>Close current page</source>

--- a/share/qtcreator/translations/qtcreator_ja.ts
+++ b/share/qtcreator/translations/qtcreator_ja.ts
@@ -19383,8 +19383,12 @@ msysgit が、git bash 外で実行された時に自身のインストール先
         <translation>バグの報告...</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head&gt;&lt;title&gt;No Documentation&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;font color=&quot;%1&quot;&gt;&lt;b&gt;%2&lt;/b&gt;&lt;/font&gt;&lt;br/&gt;&lt;font color=&quot;%3&quot;&gt;No documentation available.&lt;/font&gt;&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head&gt;&lt;title&gt;ドキュメントがありません&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;font color=&quot;%1&quot;&gt;&lt;b&gt;%2&lt;/b&gt;&lt;/font&gt;&lt;br/&gt;&lt;font color=&quot;%3&quot;&gt;使用可能なドキュメントがありません。&lt;/font&gt;&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>No Documentation</source>
+        <translation>ドキュメントがありません</translation>
+    </message>
+    <message>
+        <source>No documentation available.</source>
+        <translation>使用可能なドキュメントがありません。</translation>
     </message>
     <message>
         <source>Open Pages</source>

--- a/share/qtcreator/translations/qtcreator_pl.ts
+++ b/share/qtcreator/translations/qtcreator_pl.ts
@@ -6945,8 +6945,12 @@ Dodaj, zmodyfikuj lub usuń filtry dokumentów, które determinują zestaw dokum
         <translation>Informacje o systemie...</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head&gt;&lt;title&gt;No Documentation&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;font color=&quot;%1&quot;&gt;&lt;b&gt;%2&lt;/b&gt;&lt;/font&gt;&lt;br/&gt;&lt;font color=&quot;%3&quot;&gt;No documentation available.&lt;/font&gt;&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head&gt;&lt;title&gt;Brak dokumentacji&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;font color=&quot;%1&quot;&gt;&lt;b&gt;%2&lt;/b&gt;&lt;/font&gt;&lt;br/&gt;&lt;font color=&quot;%3&quot;&gt;Brak dostępnej dokumentacji.&lt;/font&gt;&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>No Documentation</source>
+        <translation>Brak dokumentacji</translation>
+    </message>
+    <message>
+        <source>No documentation available.</source>
+        <translation>Brak dostępnej dokumentacji.</translation>
     </message>
     <message>
         <source>System Information</source>

--- a/share/qtcreator/translations/qtcreator_ru.ts
+++ b/share/qtcreator/translations/qtcreator_ru.ts
@@ -21224,8 +21224,12 @@ Add, modify, and remove document filters, which determine the documentation set 
         <translation>Информация о системе...</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head&gt;&lt;title&gt;No Documentation&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;font color=&quot;%1&quot;&gt;&lt;b&gt;%2&lt;/b&gt;&lt;/font&gt;&lt;br/&gt;&lt;font color=&quot;%3&quot;&gt;No documentation available.&lt;/font&gt;&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head&gt;&lt;title&gt;Документация отсутствует&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;font color=&quot;%1&quot;&gt;&lt;b&gt;%2&lt;/b&gt;&lt;/font&gt;&lt;br/&gt;&lt;font color=&quot;%3&quot;&gt;Нет доступной документации.&lt;/font&gt;&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>No Documentation</source>
+        <translation>Документация отсутствует</translation>
+    </message>
+    <message>
+        <source>No documentation available.</source>
+        <translation>Нет доступной документации.</translation>
     </message>
     <message>
         <source>System Information</source>

--- a/share/qtcreator/translations/qtcreator_sl.ts
+++ b/share/qtcreator/translations/qtcreator_sl.ts
@@ -8144,9 +8144,12 @@ enojen »Vstopi« za oddajo signala pa vas bo privedel neposredno do ustrezne pr
         <translation>Nefiltrirano</translation>
     </message>
     <message>
-        <location line="+359"/>
-        <source>&lt;html&gt;&lt;head&gt;&lt;title&gt;No Documentation&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;b&gt;%1&lt;/b&gt;&lt;br/&gt;No documentation available.&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head&gt;&lt;title&gt;Ni dokumentacije&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;b&gt;%1&lt;/b&gt;&lt;br/&gt;Na voljo ni nobene dokumentacije.&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>No Documentation</source>
+        <translation>Ni dokumentacije</translation>
+    </message>
+    <message>
+        <source>No documentation available.</source>
+        <translation>Na voljo ni nobene dokumentacije.</translation>
     </message>
     <message>
         <location line="+99"/>
@@ -36872,7 +36875,7 @@ Preverite pravice za dostop do mape.</translation>
     <message>
         <location line="+6"/>
         <source>Timed out after %1s waiting for the process %2 to finish.</source>
-        <translation>Po %1 s čakanja na zaključek procesa %2 je potekel čas.</translation>
+        <translation>Po %1 s čakanja na zaključek procesa %2 je potekel čas.</translation>
     </message>
 </context>
 <context>
@@ -40106,7 +40109,7 @@ Preverite, ali je telefon priključen in ali App TRK teče.</translation>
     </message>
     <message>
         <source>Timed out after %1s waiting for mercurial process to finish.</source>
-        <translation type="obsolete">Po %1 s čakanja na zaključek procesa mercurial je potekel čas.</translation>
+        <translation type="obsolete">Po %1 s čakanja na zaključek procesa mercurial je potekel čas.</translation>
     </message>
 </context>
 <context>

--- a/share/qtcreator/translations/qtcreator_uk.ts
+++ b/share/qtcreator/translations/qtcreator_uk.ts
@@ -12589,8 +12589,12 @@ Add, modify, and remove document filters, which determine the documentation set 
         <translation>Повідомити про помилку...</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head&gt;&lt;title&gt;No Documentation&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;font color=&quot;%1&quot;&gt;&lt;b&gt;%2&lt;/b&gt;&lt;/font&gt;&lt;br/&gt;&lt;font color=&quot;%3&quot;&gt;No documentation available.&lt;/font&gt;&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head&gt;&lt;title&gt;Немає документації&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;font color=&quot;%1&quot;&gt;&lt;b&gt;%2&lt;/b&gt;&lt;/font&gt;&lt;br/&gt;&lt;font color=&quot;%3&quot;&gt;Немає доступної документації.&lt;/font&gt;&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>No Documentation</source>
+        <translation>Немає документації</translation>
+    </message>
+    <message>
+        <source>No documentation available.</source>
+        <translation>Немає доступної документації.</translation>
     </message>
     <message>
         <source>Increase Font Size</source>

--- a/share/qtcreator/translations/qtcreator_zh_CN.ts
+++ b/share/qtcreator/translations/qtcreator_zh_CN.ts
@@ -10514,8 +10514,12 @@ Add, modify, and remove document filters, which determine the documentation set 
         <translation>未过滤</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head&gt;&lt;title&gt;No Documentation&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;b&gt;%1&lt;/b&gt;&lt;br/&gt;No documentation available.&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head&gt;&lt;title&gt;没有文档&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;b&gt;%1&lt;/b&gt;&lt;br/&gt;没有可用文档。&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>No Documentation</source>
+        <translation>没有文档</translation>
+    </message>
+    <message>
+        <source>No documentation available.</source>
+        <translation>没有可用文档。</translation>
     </message>
     <message>
         <source>Close current page</source>

--- a/share/qtcreator/translations/qtcreator_zh_TW.ts
+++ b/share/qtcreator/translations/qtcreator_zh_TW.ts
@@ -6678,8 +6678,12 @@ Add, modify, and remove document filters, which determine the documentation set 
         <translation>未過濾</translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head&gt;&lt;title&gt;No Documentation&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;b&gt;%1&lt;/b&gt;&lt;br/&gt;No documentation available.&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head&gt;&lt;title&gt;沒有文件&lt;/title&gt;&lt;/head&gt;&lt;body&gt;&lt;br/&gt;&lt;center&gt;&lt;b&gt;%1&lt;/b&gt;&lt;br/&gt;沒有可用文件。&lt;/center&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <source>No Documentation</source>
+        <translation>沒有文件</translation>
+    </message>
+    <message>
+        <source>No documentation available.</source>
+        <translation>沒有可用文件。</translation>
     </message>
     <message>
         <source>Close current page</source>

--- a/src/plugins/help/helpplugin.cpp
+++ b/src/plugins/help/helpplugin.cpp
@@ -685,14 +685,17 @@ void HelpPluginPrivate::showContextHelp(const QString &contextHelpId)
     if (!source.isValid()) {
         // No link found or no context object
         showInHelpViewer(QUrl(Help::Constants::AboutBlank), viewer);
-        viewer->setHtml(HelpPlugin::tr("<html><head><title>No Documentation</title>"
-            "</head><body><br/><center>"
-            "<font color=\"%1\"><b>%2</b></font><br/>"
-            "<font color=\"%3\">No documentation available.</font>"
+        viewer->setHtml(QString("<html><head><title>%1</title>"
+            "</head><body bgcolor=\"%2\"><br/><center>"
+            "<font color=\"%3\"><b>%4</b></font><br/>"
+            "<font color=\"%5\">%6</font>"
             "</center></body></html>")
+            .arg(HelpPlugin::tr("No Documentation"))
+            .arg(creatorTheme()->color(Theme::BackgroundColorNormal).name())
             .arg(creatorTheme()->color(Theme::TextColorNormal).name())
             .arg(contextHelpId)
-            .arg(creatorTheme()->color(Theme::TextColorNormal).name()));
+            .arg(creatorTheme()->color(Theme::TextColorNormal).name())
+            .arg(HelpPlugin::tr("No documentation available.")));
     } else {
         showInHelpViewer(source, viewer);  // triggers loadFinished which triggers id highlighting
     }


### PR DESCRIPTION
This fixes the html code in the Help plugin and ensure that the background color is set.

The code has been updated in the past and causing translation to fail so I moved the strings into their own translation strings and thereby removed the possibility of future html changes from breaking translations yet again.