### PR TITLE
Rewrite qdump fns for map, set, unordered_map, unordered_set

### DIFF
--- a/share/qtcreator/debugger/stdtypes.py
+++ b/share/qtcreator/debugger/stdtypes.py
@@ -42,6 +42,19 @@ def qdump__std____1__array(d, value):
     qdump__std__array(d, value)
 
 
+def qdump__std__function(d, value):
+    (ptr, dummy1, manager, invoker) = value.split('pppp')
+    if manager:
+        if ptr > 2:
+            d.putSymbolValue(ptr)
+        else:
+            d.putEmptyValue()
+        d.putBetterType(value.type)
+    else:
+        d.putValue('(null)')
+    d.putPlainChildren(value)
+
+
 def qdump__std__complex(d, value):
     innerType = value.type[0]
     (real, imag) = value.split('{%s}{%s}' % (innerType.name, innerType.name))
@@ -526,9 +539,15 @@ def qform__std____1__map():
     return mapForms()
 
 def qdump__std____1__map(d, value):
-    (proxy, head, size) = value.split("ppp")
+    try:
+        (proxy, head, size) = value.split("ppp")
+        d.check(0 <= size and size <= 100*1000*1000)
 
-    d.check(0 <= size and size <= 100*1000*1000)
+    # Sometimes there is extra data at the front. Don't know why at the moment.
+    except RuntimeError:
+        (junk, proxy, head, size) = value.split("pppp")
+        d.check(0 <= size and size <= 100*1000*1000)
+
     d.putItemCount(size)
 
     if d.isExpanded():
@@ -874,6 +893,7 @@ def qdump__std____1__unordered_set(d, value):
             for (i, value) in zip(d.childRange(), traverse_list(curr)):
                 d.putSubItem(i, value)
 
+
 def qdump__std____debug__unordered_set(d, value):
     qdump__std__unordered_set(d, value)
 
@@ -991,6 +1011,9 @@ def qdumpHelper__std__vector__QNX(d, value):
         else:
             d.putPlotData(start, size, innerType)
 
+def qform__std____1__vector():
+    return arrayForms()
+
 def qdump__std____1__vector(d, value):
     qdumpHelper__std__vector(d, value, True)
 
@@ -1069,7 +1092,7 @@ def qdump__std____1__once_flag(d, value):
     qdump__std__once_flag(d, value)
 
 def qdump__std__once_flag(d, value):
-    d.putValue(value.extractPointer())
+    d.putValue(value.split("i")[0])
     d.putBetterType(value.type)
     d.putPlainChildren(value)
 

--- a/share/qtcreator/debugger/stdtypes.py
+++ b/share/qtcreator/debugger/stdtypes.py
@@ -503,7 +503,7 @@ def qdump__std____1__set(d, value):
         valueType = value.type[0]
 
         def in_order_traversal(node):
-            (left, right, parent, color, isnil, pad, data) = d.split("pppBB@{%s}" % (valueType.name), node)
+            (left, right, parent, color, pad, data) = d.split("pppB@{%s}" % (valueType.name), node)
 
             if left:
                 for res in in_order_traversal(left):
@@ -537,7 +537,7 @@ def qdump__std____1__map(d, value):
         pairType = value.type[3][0]
 
         def in_order_traversal(node):
-            (left, right, parent, color, isnil, pad, pair) = d.split("pppBB@{%s}" % (pairType.name), node)
+            (left, right, parent, color, pad, pair) = d.split("pppB@{%s}" % (pairType.name), node)
 
             if left:
                 for res in in_order_traversal(left):
@@ -835,7 +835,7 @@ def qform__std____1__unordered_map():
     return mapForms()
 
 def qdump__std____1__unordered_map(d, value):
-    size = int(value["__table_"]["__p2_"]["__first_"])
+    (size, _) = value["__table_"]["__p2_"].split("pp")
     d.putItemCount(size)
 
     keyType = value.type[0]
@@ -843,8 +843,7 @@ def qdump__std____1__unordered_map(d, value):
     pairType = value.type[4][0]
 
     if d.isExpanded():
-        head = value["__table_"]["__p1_"]["__first_"]["__next_"]
-        (curr,) = head.split("p")
+        curr = value["__table_"]["__p1_"].split("pp")[0]
 
         def traverse_list(node):
             while node:
@@ -857,14 +856,13 @@ def qdump__std____1__unordered_map(d, value):
                 d.putPairItem(i, value, 'key', 'value')
 
 def qdump__std____1__unordered_set(d, value):
-    size = int(value["__table_"]["__p2_"]["__first_"])
+    (size, _) = value["__table_"]["__p2_"].split("pp")
     d.putItemCount(size)
 
     valueType = value.type[0]
 
     if d.isExpanded():
-        head = value["__table_"]["__p1_"]["__first_"]["__next_"]
-        (curr,) = head.split("p")
+        curr = value["__table_"]["__p1_"].split("pp")[0]
 
         def traverse_list(node):
             while node:
@@ -1075,7 +1073,6 @@ def qdump__std__once_flag(d, value):
     d.putBetterType(value.type)
     d.putPlainChildren(value)
 
-
 def qdump____gnu_cxx__hash_set(d, value):
     ht = value["_M_ht"]
     size = ht["_M_num_elements"].integer()
@@ -1098,7 +1095,6 @@ def qdump____gnu_cxx__hash_set(d, value):
                         cur = cur["_M_next"]
                         itemCount += 1
                 p = p + 1
-
 
 def qdump__uint8_t(d, value):
     d.putNumChild(0)


### PR DESCRIPTION
This is a fix for the issue of not being able to view std::map contents in the debugger window (<not accessible> instead, which is caused by the underlying python script throwing an Exception). Rewrote debugger helper `qdump__std____1__map(d, value)` which was previously not working on most platforms that I've seen (I have not seen any platforms work, but have not tested all). Was crashing previously trying to get members that don't exist from the tree resulting in <not accessible> message on debugger.

This rewrite has been proven to work on Macs so far.