### PR TITLE
Debugger: Fix mapping std::set in Locals window via gdb

### DIFF
--- a/share/qtcreator/debugger/stdtypes.py
+++ b/share/qtcreator/debugger/stdtypes.py
@@ -442,7 +442,7 @@ def qdump__std__set(d, value):
                 d.putSubItem(i, val)
                 if node["_M_right"].pointer() == 0:
                     parent = node["_M_parent"]
-                    while node == parent["_M_right"]:
+                    while node.pointer() == parent["_M_right"].pointer():
                         node = parent
                         parent = parent["_M_parent"]
                     if node["_M_right"] != parent:


### PR DESCRIPTION
Currently QtCreator shows a set's content incorrectly
![image](https://user-images.githubusercontent.com/48147466/63634514-38959d00-c660-11e9-8c95-fe989c7e5838.png)

Fixed behaviour
![image](https://user-images.githubusercontent.com/48147466/63634509-18fe7480-c660-11e9-8b9e-8e5b992dba42.png)


