### PR TITLE
Fix for lower case address values in debugging view

### DIFF
--- a/src/plugins/debugger/gdb/gdbengine.cpp
+++ b/src/plugins/debugger/gdb/gdbengine.cpp
@@ -3261,7 +3261,7 @@ void GdbEngine::handlePeripheralRegisterListValues(
 
     const QString output = response.consoleStreamOutput;
     // Regexp to match for '0x50060800:\t0\n'.
-    const QRegularExpression re("^(0x[0-9A-F]+):\\t(\\d+)\\n$");
+    const QRegularExpression re("^(0x[0-9A-Fa-f]+):\\t(\\d+)\\n$");
     const QRegularExpressionMatch m = re.match(output);
     if (!m.hasMatch())
         return;


### PR DESCRIPTION
when the gdbserver responds with addresses that contain hexadecimal addresses with lower case characters the match was always false. This lead to the problem that some registers are not being displayed correctly but only filled with zeros.