### PR TITLE
fix endless loop when tokens do not represent a lambda

### DIFF
--- a/src/libs/cplusplus/ExpressionUnderCursor.cpp
+++ b/src/libs/cplusplus/ExpressionUnderCursor.cpp
@@ -183,6 +183,7 @@ int ExpressionUnderCursor::startOfExpression_helper(BackwardsScanner &tk, int in
                             int leftParenIndex = tk.startOfMatchingBrace(currentIndex);
                             if (tk[leftParenIndex-1].is(T_THROW)) {
                                 currentIndex = leftParenIndex-1;
+                                continue;
                             } else if (tk[leftParenIndex-1].is(T_RBRACKET)) {
                                 int leftBracketIndex = tk.startOfMatchingBrace(leftParenIndex);
                                 if (leftBracketIndex != leftParenIndex-1)
@@ -192,9 +193,8 @@ int ExpressionUnderCursor::startOfExpression_helper(BackwardsScanner &tk, int in
                             int leftBracketIndex = tk.startOfMatchingBrace(currentIndex);
                             if (leftBracketIndex != currentIndex-1)
                                 return leftBracketIndex;
-                        } else {
-                            --currentIndex;
                         }
+                        --currentIndex;
                     }
                 }
             }


### PR DESCRIPTION
I have experienced an endless loop traversing the callstack when the tokens do not represent a lambda, like for instance something like:

`return Class{}(var);`

With this patch we always decrement `currentIndex` except for the `T_THROW` case which seems like as much i could understand it is not wanted (I haven't tested that case).

best regards