### PR TITLE
Remove Latin1 from String usage to support Utf8

### DIFF
--- a/src/plugins/cppeditor/cppfilesettingspage.cpp
+++ b/src/plugins/cppeditor/cppfilesettingspage.cpp
@@ -119,11 +119,11 @@ void CppFileSettings::fromSettings(QSettings *s)
 bool CppFileSettings::applySuffixesToMimeDB()
 {
     Utils::MimeType mt;
-    mt = Utils::mimeTypeForName(QLatin1String(Constants::CPP_SOURCE_MIMETYPE));
+    mt = Utils::mimeTypeForName(QString(Constants::CPP_SOURCE_MIMETYPE));
     if (!mt.isValid())
         return false;
     mt.setPreferredSuffix(sourceSuffix);
-    mt = Utils::mimeTypeForName(QLatin1String(Constants::CPP_HEADER_MIMETYPE));
+    mt = Utils::mimeTypeForName(QString(Constants::CPP_HEADER_MIMETYPE));
     if (!mt.isValid())
         return false;
     mt.setPreferredSuffix(headerSuffix);
@@ -147,49 +147,49 @@ bool CppFileSettings::equals(const CppFileSettings &rhs) const
 static bool keyWordReplacement(const QString &keyWord,
                                QString *value)
 {
-    if (keyWord == QLatin1String("%YEAR%")) {
-        *value = QLatin1String("%{CurrentDate:yyyy}");
+    if (keyWord == QString("%YEAR%")) {
+        *value = QString("%{CurrentDate:yyyy}");
         return true;
     }
-    if (keyWord == QLatin1String("%MONTH%")) {
-        *value = QLatin1String("%{CurrentDate:M}");
+    if (keyWord == QString("%MONTH%")) {
+        *value = QString("%{CurrentDate:M}");
         return true;
     }
-    if (keyWord == QLatin1String("%DAY%")) {
-        *value = QLatin1String("%{CurrentDate:d}");
+    if (keyWord == QString("%DAY%")) {
+        *value = QString("%{CurrentDate:d}");
         return true;
     }
-    if (keyWord == QLatin1String("%CLASS%")) {
-        *value = QLatin1String("%{Cpp:License:ClassName}");
+    if (keyWord == QString("%CLASS%")) {
+        *value = QString("%{Cpp:License:ClassName}");
         return true;
     }
-    if (keyWord == QLatin1String("%FILENAME%")) {
-        *value = QLatin1String("%{Cpp:License:FileName}");
+    if (keyWord == QString("%FILENAME%")) {
+        *value = QString("%{Cpp:License:FileName}");
         return true;
     }
-    if (keyWord == QLatin1String("%DATE%")) {
+    if (keyWord == QString("%DATE%")) {
         static QString format;
         // ensure a format with 4 year digits. Some have locales have 2.
         if (format.isEmpty()) {
             QLocale loc;
             format = loc.dateFormat(QLocale::ShortFormat);
-            const QChar ypsilon = QLatin1Char('y');
+            const QChar ypsilon('y');
             if (format.count(ypsilon) == 2)
                 format.insert(format.indexOf(ypsilon), QString(2, ypsilon));
             format.replace('/', "\\/");
         }
-        *value = QString::fromLatin1("%{CurrentDate:") + format + QLatin1Char('}');
+        *value = QString("%{CurrentDate:") + format + QChar('}');
         return true;
     }
-    if (keyWord == QLatin1String("%USER%")) {
-        *value = Utils::HostOsInfo::isWindowsHost() ? QLatin1String("%{Env:USERNAME}")
-                                                    : QLatin1String("%{Env:USER}");
+    if (keyWord == QString("%USER%")) {
+        *value = Utils::HostOsInfo::isWindowsHost() ? QString("%{Env:USERNAME}")
+                                                    : QString("%{Env:USER}");
         return true;
     }
     // Environment variables (for example '%$EMAIL%').
-    if (keyWord.startsWith(QLatin1String("%$"))) {
+    if (keyWord.startsWith(QString("%$"))) {
         const QString varName = keyWord.mid(2, keyWord.size() - 3);
-        *value = QString::fromLatin1("%{Env:") + varName + QLatin1Char('}');
+        *value = QString("%{Env:") + varName + QChar('}');
         return true;
     }
     return false;
@@ -200,7 +200,7 @@ static bool keyWordReplacement(const QString &keyWord,
 static void parseLicenseTemplatePlaceholders(QString *t)
 {
     int pos = 0;
-    const QChar placeHolder = QLatin1Char('%');
+    const QChar placeHolder('%');
     do {
         const int placeHolderPos = t->indexOf(placeHolder, pos);
         if (placeHolderPos == -1)
@@ -230,9 +230,9 @@ static void parseLicenseTemplatePlaceholders(QString *t)
 QString CppFileSettings::licenseTemplate()
 {
     const QSettings *s = Core::ICore::settings();
-    QString key = QLatin1String(Constants::CPPEDITOR_SETTINGSGROUP);
-    key += QLatin1Char('/');
-    key += QLatin1String(licenseTemplatePathKeyC);
+    QString key(Constants::CPPEDITOR_SETTINGSGROUP);
+    key += QChar('/');
+    key += QString(licenseTemplatePathKeyC);
     const QString path = s->value(key, QString()).toString();
     if (path.isEmpty())
         return QString();
@@ -249,7 +249,7 @@ QString CppFileSettings::licenseTemplate()
     parseLicenseTemplatePlaceholders(&license);
 
     // Ensure at least one newline at the end of the license template to separate it from the code
-    const QChar newLine = QLatin1Char('\n');
+    const QChar newLine = QChar('\n');
     if (!license.endsWith(newLine))
         license += newLine;
 
@@ -283,19 +283,19 @@ CppFileSettingsWidget::CppFileSettingsWidget(CppFileSettings *settings)
 {
     m_ui.setupUi(this);
     // populate suffix combos
-    const Utils::MimeType sourceMt = Utils::mimeTypeForName(QLatin1String(Constants::CPP_SOURCE_MIMETYPE));
+    const Utils::MimeType sourceMt = Utils::mimeTypeForName(QString(Constants::CPP_SOURCE_MIMETYPE));
     if (sourceMt.isValid()) {
         foreach (const QString &suffix, sourceMt.suffixes())
             m_ui.sourceSuffixComboBox->addItem(suffix);
     }
 
-    const Utils::MimeType headerMt = Utils::mimeTypeForName(QLatin1String(Constants::CPP_HEADER_MIMETYPE));
+    const Utils::MimeType headerMt = Utils::mimeTypeForName(QString(Constants::CPP_HEADER_MIMETYPE));
     if (headerMt.isValid()) {
         foreach (const QString &suffix, headerMt.suffixes())
             m_ui.headerSuffixComboBox->addItem(suffix);
     }
     m_ui.licenseTemplatePathChooser->setExpectedKind(Utils::PathChooser::File);
-    m_ui.licenseTemplatePathChooser->setHistoryCompleter(QLatin1String("Cpp.LicenseTemplate.History"));
+    m_ui.licenseTemplatePathChooser->setHistoryCompleter(QString("Cpp.LicenseTemplate.History"));
     m_ui.licenseTemplatePathChooser->addButton(tr("Edit..."), this, [this] { slotEdit(); });
 
     setSettings(*m_settings);
@@ -314,7 +314,7 @@ void CppFileSettingsWidget::setLicenseTemplatePath(const FilePath &lp)
 static QStringList trimmedPaths(const QString &paths)
 {
     QStringList res;
-    foreach (const QString &path, paths.split(QLatin1Char(','), Qt::SkipEmptyParts))
+    foreach (const QString &path, paths.split(QChar(','), Qt::SkipEmptyParts))
         res << path.trimmed();
     return res;
 }
@@ -349,7 +349,7 @@ static inline void setComboText(QComboBox *cb, const QString &text, int defaultI
 
 void CppFileSettingsWidget::setSettings(const CppFileSettings &s)
 {
-    const QChar comma = QLatin1Char(',');
+    const QChar comma(',');
     m_ui.lowerCaseFileNamesCheckBox->setChecked(s.lowerCaseFiles);
     m_ui.headerPragmaOnceCheckBox->setChecked(s.headerPragmaOnce);
     m_ui.headerPrefixesEdit->setText(s.headerPrefixes.join(comma));


### PR DESCRIPTION
The text Stream has licenseStream.setAutoDetectUnicode(true);
but was destroyed by using Latin1 versions of the loaded strings