### PR TITLE
share/share.pro: fix .desktop file path

### DIFF
--- a/share/share.pro
+++ b/share/share.pro
@@ -12,7 +12,7 @@ linux {
     appstream.files = $$OUT_PWD/metainfo/org.qt-project.qtcreator.appdata.xml
     appstream.path = $$QTC_PREFIX/share/metainfo/
 
-    desktop.files = share/applications/org.qt-project.qtcreator.desktop
+    desktop.files = $$PWD/applications/org.qt-project.qtcreator.desktop
     desktop.path = $$QTC_PREFIX/share/applications/
 
     INSTALLS += appstream desktop


### PR DESCRIPTION
Hello,

This is a small fix so qt-creator's desktop file is properly installed.

Related [bug ticket](https://bugs.gentoo.org/828071)

Adel