### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -657,6 +657,8 @@ jobs:
         name: ${{ steps.ccache.outputs.archive_name }}
 
   release:
+    permissions:
+      contents: write  # for actions/create-release to create a release
     if: contains(github.ref, 'tags/v')
     runs-on: ubuntu-latest
     needs: build
@@ -683,6 +685,8 @@ jobs:
         name: upload_url
 
   publish:
+    permissions:
+      contents: write  # for actions/upload-release-asset to upload release asset
     if: contains(github.ref, 'tags/v')
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
