### PR TITLE
Early break when no artifacts are available.

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -435,6 +435,9 @@ jobs:
           file(READ artifacts.json artifacts_json)
 
           string(JSON artifacts_length LENGTH "${artifacts_json}" "artifacts")
+          if (artifacts_length LESS 1)
+            break()
+          endif()
           math(EXPR artifacts_length "${artifacts_length} - 1")
           foreach(idx RANGE 0 ${artifacts_length})
             string(JSON artifact_js GET "${artifacts_json}" "artifacts" ${idx})


### PR DESCRIPTION
If there are no artifacts at a page, build fails because
```
string(JSON artifacts_length LENGTH "${artifacts_json}" "artifacts")
foreach(idx RANGE 0 ${artifacts_length})
```
*artifacts_length* is -1 and then `stop` is smaller than start in the foreach loop.